### PR TITLE
Move assisted tokens from foundations to component

### DIFF
--- a/src/Assisted/ProgressBar/styles.js
+++ b/src/Assisted/ProgressBar/styles.js
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { inube } from "@inubekit/foundations";
+import { tokens } from "../Tokens/tokens";
 
 const StyledProgressBar = styled.div`
   border-radius: 10px;
@@ -7,7 +7,7 @@ const StyledProgressBar = styled.div`
   height: 16px;
   width: 100%;
   background-color: ${({ theme }) =>
-    theme?.assisted?.track?.color || inube.assisted.track.color};
+    theme?.assisted?.track?.color || tokens.track.color};
 
   &::before {
     content: "";
@@ -18,7 +18,7 @@ const StyledProgressBar = styled.div`
     width: ${({ $currentStep, $totalSteps }) =>
       `${($currentStep / $totalSteps) * 100}%`};
     background: ${({ theme }) =>
-      theme?.assisted?.bar?.color || inube.assisted.bar.color};
+      theme?.assisted?.bar?.color || tokens.bar.color};
   }
 `;
 

--- a/src/Assisted/StepIndicator/index.tsx
+++ b/src/Assisted/StepIndicator/index.tsx
@@ -3,9 +3,9 @@ import { Icon, IIcon } from "@inubekit/icon";
 import { MdCheckCircle } from "react-icons/md";
 
 import { StyledStepIndicator } from "./styles";
-import { inube } from "@inubekit/foundations";
 import { useContext } from "react";
 import { ThemeContext } from "styled-components";
+import { tokens } from "../Tokens/tokens";
 
 interface IStepIndicator {
   stepNumber: number;
@@ -14,7 +14,7 @@ interface IStepIndicator {
 
 function StepIndicator(props: IStepIndicator) {
   const { stepNumber, isLastStep } = props;
-  const theme: typeof inube = useContext(ThemeContext);
+  const theme = useContext(ThemeContext) as { assisted: typeof tokens };
 
   return (
     <StyledStepIndicator>
@@ -23,7 +23,7 @@ function StepIndicator(props: IStepIndicator) {
           appearance={
             theme
               ? (theme.assisted.button.appearance as IIcon["appearance"])
-              : (inube.assisted.button.appearance as IIcon["appearance"])
+              : (tokens.button.appearance as IIcon["appearance"])
           }
           icon={<MdCheckCircle />}
           size="20px"

--- a/src/Assisted/StepIndicator/styles.js
+++ b/src/Assisted/StepIndicator/styles.js
@@ -1,6 +1,5 @@
 import styled from "styled-components";
-
-import { inube } from "@inubekit/foundations";
+import { tokens } from "../Tokens/tokens";
 
 const StyledStepIndicator = styled.div`
   display: flex;
@@ -12,7 +11,7 @@ const StyledStepIndicator = styled.div`
   border-width: 2px;
   border-style: solid;
   border-color: ${({ theme }) =>
-    theme?.assisted?.step?.color || inube.assisted.step.color};
+    theme?.assisted?.step?.color || tokens.step.color};
 `;
 
 export { StyledStepIndicator };

--- a/src/Assisted/Tokens/tokens.ts
+++ b/src/Assisted/Tokens/tokens.ts
@@ -1,0 +1,27 @@
+import { inube } from "@inubekit/foundations";
+
+const tokens = {
+  title: {
+    appearance: "dark",
+  },
+  description: {
+    appearance: "gray",
+  },
+  track: {
+    color: inube.palette.neutral.N30,
+  },
+  bar: {
+    color: inube.palette.blue.B400,
+  },
+  background: {
+    color: inube.palette.neutral.N10,
+  },
+  button: {
+    appearance: "primary",
+  },
+  step: {
+    color: inube.palette.blue.B400,
+  },
+};
+
+export { tokens };

--- a/src/Assisted/index.tsx
+++ b/src/Assisted/index.tsx
@@ -1,5 +1,4 @@
 import { AssistedUI } from "./interface";
-
 import { IAssistedStep, IAssistedSize, IAssistedControls } from "./props";
 
 interface IAssisted {

--- a/src/Assisted/interface.tsx
+++ b/src/Assisted/interface.tsx
@@ -1,7 +1,5 @@
 import { useContext } from "react";
 import { ThemeContext } from "styled-components";
-
-import { inube } from "@inubekit/foundations";
 import { Grid } from "@inubekit/grid";
 import { Stack } from "@inubekit/stack";
 import { IText, Text } from "@inubekit/text";
@@ -17,6 +15,7 @@ import { StepIndicator } from "./StepIndicator";
 
 import { StyledAssisted } from "./styles";
 import { IIcon } from "@inubekit/icon";
+import { tokens } from "./Tokens/tokens";
 
 interface IAssistedUI {
   size: IAssisted["size"];
@@ -44,7 +43,7 @@ function AssistedUI(props: IAssistedUI) {
     onSubmitClick,
     controls,
   } = props;
-  const theme: typeof inube = useContext(ThemeContext);
+  const theme = useContext(ThemeContext) as { assisted: typeof tokens };
 
   function isLastStep() {
     return step.number === totalSteps;
@@ -63,7 +62,7 @@ function AssistedUI(props: IAssistedUI) {
             appearance={
               theme
                 ? (theme.assisted.button.appearance as IButton["appearance"])
-                : (inube.assisted.button.appearance as IButton["appearance"])
+                : (tokens.button.appearance as IButton["appearance"])
             }
           >
             {controls!.goBackText}
@@ -82,7 +81,7 @@ function AssistedUI(props: IAssistedUI) {
                 appearance={
                   theme
                     ? (theme.assisted.title.appearance as IText["appearance"])
-                    : (inube.assisted.title.appearance as IText["appearance"])
+                    : (tokens.title.appearance as IText["appearance"])
                 }
               >
                 {step.name}
@@ -100,8 +99,7 @@ function AssistedUI(props: IAssistedUI) {
                 theme
                   ? (theme.assisted.description
                       .appearance as IText["appearance"])
-                  : (inube.assisted.description
-                      .appearance as IText["appearance"])
+                  : (tokens.description.appearance as IText["appearance"])
               }
               size="medium"
               weight="bold"
@@ -117,7 +115,7 @@ function AssistedUI(props: IAssistedUI) {
             appearance={
               theme
                 ? (theme.assisted.button.appearance as IButton["appearance"])
-                : (inube.assisted.button.appearance as IButton["appearance"])
+                : (tokens.button.appearance as IButton["appearance"])
             }
             onClick={() => {
               isLastStep() ? onSubmitClick(step) : onNextClick(step);
@@ -143,7 +141,7 @@ function AssistedUI(props: IAssistedUI) {
             appearance={
               theme
                 ? (theme.assisted.button.appearance as IIcon["appearance"])
-                : (inube.assisted.button.appearance as IIcon["appearance"])
+                : (tokens.button.appearance as IIcon["appearance"])
             }
           />
           <Stack alignItems="center" gap="8px">
@@ -156,7 +154,7 @@ function AssistedUI(props: IAssistedUI) {
               appearance={
                 theme
                   ? (theme.assisted.title.appearance as IText["appearance"])
-                  : (inube.assisted.title.appearance as IText["appearance"])
+                  : (tokens.title.appearance as IText["appearance"])
               }
             >
               {step.name}
@@ -173,7 +171,7 @@ function AssistedUI(props: IAssistedUI) {
             appearance={
               theme
                 ? (theme.assisted.button.appearance as IIcon["appearance"])
-                : (inube.assisted.button.appearance as IIcon["appearance"])
+                : (tokens.button.appearance as IIcon["appearance"])
             }
           />
         </Grid>
@@ -183,7 +181,7 @@ function AssistedUI(props: IAssistedUI) {
           appearance={
             theme
               ? (theme.assisted.description.appearance as IText["appearance"])
-              : (inube.assisted.description.appearance as IText["appearance"])
+              : (tokens.description.appearance as IText["appearance"])
           }
           size="medium"
           weight="bold"

--- a/src/Assisted/stories/Assisted.stories.tsx
+++ b/src/Assisted/stories/Assisted.stories.tsx
@@ -1,10 +1,9 @@
 import { parameters, props } from "../props";
 import { AssistedController, IAssistedController } from "./Assisted.Controller";
-import { Assisted } from "..";
 
 const story = {
   title: "Feedback/Assisted",
-  component: Assisted,
+  component: AssistedController,
   parameters,
   argTypes: props,
 };

--- a/src/Assisted/styles.js
+++ b/src/Assisted/styles.js
@@ -1,11 +1,11 @@
 import styled from "styled-components";
-import { inube } from "@inubekit/foundations";
+import { tokens } from "./Tokens/tokens";
 
 const StyledAssisted = styled.div`
   border-radius: 8px;
   padding: ${({ $size }) => ($size === "large" ? "16px" : "12px")};
   background-color: ${({ theme }) =>
-    theme?.assisted?.background?.color || inube.assisted.background.color};
+    theme?.assisted?.background?.color || tokens.background.color};
 `;
 
 export { StyledAssisted };


### PR DESCRIPTION
This PR relocates the assisted tokens from the foundations folder to the respective component folder, updating all relevant imports to reflect the new structure and ensuring components are referencing the correct token paths. This change improves the modularity, maintainability, and clarity of the codebase.